### PR TITLE
fix wrapper name for node6, node8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ export default class IOpipeLayerPlugin {
   private getHandlerWrapper(runtime: string, handler: string) {
     if (["nodejs6.10", "nodejs8.10"].indexOf(runtime) !== -1) {
       this.addNodeHelper();
-      return "iopipe_wrapper.handler";
+      return "iopipe-wrapper.handler";
     }
 
     if (runtime === "nodejs10.x") {


### PR DESCRIPTION
This plugin is failing for me on node8 as of `0.3.2`. Looks like there was one place that wasn't renamed to `iopipe-wrapper`